### PR TITLE
feat(details): Implement comprehensive movie and TV show detail pages

### DIFF
--- a/app/movie/[id]/page.tsx
+++ b/app/movie/[id]/page.tsx
@@ -9,9 +9,9 @@ import CrewSection from '@/components/CrewSection/CrewSection';
 import ProductionCompanies from '@/components/ProductionCompanies/ProductionCompanies';
 
 interface MoviePageProps {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export async function generateMetadata({

--- a/app/movie/[id]/page.tsx
+++ b/app/movie/[id]/page.tsx
@@ -1,0 +1,114 @@
+import { notFound } from 'next/navigation';
+import { getMovieDetails, getMovieCredits, tmdbImageUrl } from '@/lib/tmdb';
+import { Metadata } from 'next';
+import HeroSection from '@/components/HeroSection/HeroSection';
+import MetadataCard from '@/components/MetadataCard/MetadataCard';
+import OverviewSection from '@/components/OverviewSection/OverviewSection';
+import CastGrid from '@/components/CastGrid/CastGrid';
+import CrewSection from '@/components/CrewSection/CrewSection';
+import ProductionCompanies from '@/components/ProductionCompanies/ProductionCompanies';
+
+interface MoviePageProps {
+  params: {
+    id: string;
+  };
+}
+
+export async function generateMetadata({
+  params,
+}: MoviePageProps): Promise<Metadata> {
+  try {
+    const resolvedParams = await params;
+    const movieId = parseInt(resolvedParams.id);
+    if (isNaN(movieId)) {
+      return { title: 'Movie Not Found' };
+    }
+
+    const movie = await getMovieDetails(movieId);
+
+    return {
+      title: `${movie.title} (${new Date(movie.release_date).getFullYear()})`,
+      description: movie.overview || `Details for ${movie.title}`,
+      openGraph: {
+        title: movie.title,
+        description: movie.overview || '',
+        images: movie.poster_path
+          ? [tmdbImageUrl.poster(movie.poster_path, 'w500') || '']
+          : [],
+      },
+    };
+  } catch {
+    return { title: 'Movie Not Found' };
+  }
+}
+
+export default async function MoviePage({ params }: MoviePageProps) {
+  const resolvedParams = await params;
+  const movieId = parseInt(resolvedParams.id);
+
+  if (isNaN(movieId)) {
+    notFound();
+  }
+
+  try {
+    const [movie, credits] = await Promise.all([
+      getMovieDetails(movieId, { appendToResponse: ['videos', 'images'] }),
+      getMovieCredits(movieId),
+    ]);
+
+    const posterUrl = tmdbImageUrl.poster(movie.poster_path, 'w500');
+    const backdropUrl = tmdbImageUrl.backdrop(movie.backdrop_path, 'w1280');
+
+    // Prepare metadata for the MetadataCard
+    const metadata = [];
+    if (movie.budget > 0) {
+      metadata.push({
+        label: 'Budget',
+        value: movie.budget,
+        format: 'currency' as const,
+      });
+    }
+    if (movie.revenue > 0) {
+      metadata.push({
+        label: 'Revenue',
+        value: movie.revenue,
+        format: 'currency' as const,
+      });
+    }
+
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <HeroSection
+          backdropPath={backdropUrl}
+          title={movie.title}
+          subtitle={`${new Date(movie.release_date).getFullYear()} • ${movie.runtime} min`}
+          alt={movie.title}
+        />
+
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            <MetadataCard
+              posterUrl={posterUrl || undefined}
+              title={movie.title}
+              rating={movie.vote_average}
+              voteCount={movie.vote_count}
+              genres={movie.genres}
+              releaseDate={movie.release_date}
+              status={movie.status}
+              metadata={metadata}
+            />
+
+            <div className="lg:col-span-2 space-y-8">
+              <OverviewSection overview={movie.overview} />
+              <CastGrid cast={credits.cast} />
+              <CrewSection crew={credits.crew} />
+              <ProductionCompanies companies={movie.production_companies} />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/app/tv/[id]/page.tsx
+++ b/app/tv/[id]/page.tsx
@@ -1,0 +1,127 @@
+import { notFound } from 'next/navigation';
+import { getTVShowDetails, getTVShowCredits, tmdbImageUrl } from '@/lib/tmdb';
+import { Metadata } from 'next';
+import HeroSection from '@/components/HeroSection/HeroSection';
+import MetadataCard from '@/components/MetadataCard/MetadataCard';
+import OverviewSection from '@/components/OverviewSection/OverviewSection';
+import CastGrid from '@/components/CastGrid/CastGrid';
+import CrewSection from '@/components/CrewSection/CrewSection';
+import ProductionCompanies from '@/components/ProductionCompanies/ProductionCompanies';
+import SeasonsSection from '@/components/SeasonsSection/SeasonsSection';
+
+interface TVShowPageProps {
+  params: {
+    id: string;
+  };
+}
+
+export async function generateMetadata({
+  params,
+}: TVShowPageProps): Promise<Metadata> {
+  try {
+    const resolvedParams = await params;
+    const tvId = parseInt(resolvedParams.id);
+    if (isNaN(tvId)) {
+      return { title: 'TV Show Not Found' };
+    }
+
+    const show = await getTVShowDetails(tvId);
+
+    return {
+      title: `${show.name} (${new Date(show.first_air_date).getFullYear()})`,
+      description: show.overview || `Details for ${show.name}`,
+      openGraph: {
+        title: show.name,
+        description: show.overview || '',
+        images: show.poster_path
+          ? [tmdbImageUrl.poster(show.poster_path, 'w500') || '']
+          : [],
+      },
+    };
+  } catch {
+    return { title: 'TV Show Not Found' };
+  }
+}
+
+export default async function TVShowPage({ params }: TVShowPageProps) {
+  const resolvedParams = await params;
+  const tvId = parseInt(resolvedParams.id);
+
+  if (isNaN(tvId)) {
+    notFound();
+  }
+
+  try {
+    const [show, credits] = await Promise.all([
+      getTVShowDetails(tvId, { appendToResponse: ['videos', 'images'] }),
+      getTVShowCredits(tvId),
+    ]);
+
+    const posterUrl = tmdbImageUrl.poster(show.poster_path, 'w500');
+    const backdropUrl = tmdbImageUrl.backdrop(show.backdrop_path, 'w1280');
+
+    // Prepare metadata for the MetadataCard
+    const metadata: Array<{
+      label: string;
+      value: string | number;
+      format?: 'currency' | 'date' | 'number';
+    }> = [
+      { label: 'Type', value: show.type || 'TV Show' },
+      { label: 'Seasons', value: show.number_of_seasons },
+      { label: 'Episodes', value: show.number_of_episodes },
+    ];
+
+    if (show.last_air_date) {
+      metadata.push({
+        label: 'Last Aired',
+        value: show.last_air_date,
+        format: 'date' as const,
+      });
+    }
+
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <HeroSection
+          backdropPath={backdropUrl}
+          title={show.name}
+          subtitle={`${new Date(show.first_air_date).getFullYear()} • ${show.number_of_seasons} Season${show.number_of_seasons !== 1 ? 's' : ''}`}
+          alt={show.name}
+        />
+
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            <MetadataCard
+              posterUrl={posterUrl || undefined}
+              title={show.name}
+              rating={show.vote_average}
+              voteCount={show.vote_count}
+              genres={show.genres}
+              releaseDate={show.first_air_date}
+              status={show.status}
+              metadata={metadata}
+            />
+
+            <div className="lg:col-span-2 space-y-8">
+              <OverviewSection overview={show.overview} />
+              <SeasonsSection seasons={show.seasons} />
+              <CastGrid cast={credits.cast} />
+              <CrewSection
+                crew={credits.crew}
+                keyRoles={[
+                  'Creator',
+                  'Executive Producer',
+                  'Producer',
+                  'Director',
+                  'Writer',
+                ]}
+              />
+              <ProductionCompanies companies={show.production_companies} />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/app/tv/[id]/page.tsx
+++ b/app/tv/[id]/page.tsx
@@ -10,9 +10,9 @@ import ProductionCompanies from '@/components/ProductionCompanies/ProductionComp
 import SeasonsSection from '@/components/SeasonsSection/SeasonsSection';
 
 interface TVShowPageProps {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export async function generateMetadata({

--- a/components/CastGrid/CastGrid.tsx
+++ b/components/CastGrid/CastGrid.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image';
+import { tmdbImageUrl } from '@/lib/tmdb';
+import type { TMDBCastMember } from '@/types/tmdb';
+
+interface CastGridProps {
+  cast: TMDBCastMember[];
+  maxItems?: number;
+}
+
+export default function CastGrid({ cast, maxItems = 12 }: CastGridProps) {
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h2 className="text-2xl font-bold text-gray-900 mb-6">Cast</h2>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {cast.slice(0, maxItems).map((actor) => (
+          <div key={actor.id} className="text-center">
+            {actor.profile_path ? (
+              <Image
+                src={tmdbImageUrl.profile(actor.profile_path, 'w185') || ''}
+                alt={actor.name}
+                width={185}
+                height={278}
+                className="w-full h-32 object-cover rounded-lg mb-2"
+              />
+            ) : (
+              <div className="w-full h-32 bg-gray-200 rounded-lg mb-2 flex items-center justify-center">
+                <span className="text-gray-400 text-xs">No Image</span>
+              </div>
+            )}
+            <h3 className="font-medium text-gray-900 text-sm mb-1">
+              {actor.name}
+            </h3>
+            <p className="text-gray-500 text-xs">{actor.character}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/CrewSection/CrewSection.tsx
+++ b/components/CrewSection/CrewSection.tsx
@@ -1,0 +1,59 @@
+import Image from 'next/image';
+import { tmdbImageUrl } from '@/lib/tmdb';
+import type { TMDBCrewMember } from '@/types/tmdb';
+
+interface CrewSectionProps {
+  crew: TMDBCrewMember[];
+  maxItems?: number;
+  keyRoles?: string[];
+}
+
+export default function CrewSection({
+  crew,
+  maxItems = 9,
+  keyRoles = [
+    'Director',
+    'Producer',
+    'Executive Producer',
+    'Screenplay',
+    'Writer',
+  ],
+}: CrewSectionProps) {
+  const filteredCrew = crew
+    .filter((person) => keyRoles.includes(person.job))
+    .slice(0, maxItems);
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h2 className="text-2xl font-bold text-gray-900 mb-6">Key Crew</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredCrew.map((person, index) => (
+          <div
+            key={`${person.id}-${index}`}
+            className="flex items-center space-x-3"
+          >
+            {person.profile_path ? (
+              <Image
+                src={tmdbImageUrl.profile(person.profile_path, 'w185') || ''}
+                alt={person.name}
+                width={40}
+                height={60}
+                className="w-10 h-10 object-cover rounded-full"
+              />
+            ) : (
+              <div className="w-10 h-10 bg-gray-200 rounded-full flex items-center justify-center">
+                <span className="text-gray-400 text-xs">?</span>
+              </div>
+            )}
+            <div>
+              <h3 className="font-medium text-gray-900 text-sm">
+                {person.name}
+              </h3>
+              <p className="text-gray-500 text-xs">{person.job}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/HeroSection/HeroSection.tsx
+++ b/components/HeroSection/HeroSection.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image';
+
+interface HeroSectionProps {
+  backdropPath: string | null;
+  title: string;
+  subtitle: string;
+  alt: string;
+}
+
+export default function HeroSection({
+  backdropPath,
+  title,
+  subtitle,
+  alt,
+}: HeroSectionProps) {
+  return (
+    <div className="relative h-96 w-full overflow-hidden">
+      {backdropPath && (
+        <Image
+          src={backdropPath}
+          alt={alt}
+          fill
+          className="object-cover"
+          priority
+        />
+      )}
+      <div className="absolute inset-0 bg-black/50" />
+      <div className="absolute bottom-8 left-8 text-white">
+        <h1 className="text-4xl font-bold mb-2">{title}</h1>
+        <p className="text-lg opacity-90">{subtitle}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/MetadataCard/MetadataCard.tsx
+++ b/components/MetadataCard/MetadataCard.tsx
@@ -1,0 +1,112 @@
+import Image from 'next/image';
+import type { TMDBGenre } from '@/types/tmdb';
+
+interface MetadataItem {
+  label: string;
+  value: string | number;
+  format?: 'currency' | 'date' | 'number';
+}
+
+interface MetadataCardProps {
+  posterUrl?: string;
+  title: string;
+  rating: number;
+  voteCount: number;
+  genres: TMDBGenre[];
+  releaseDate?: string;
+  status?: string;
+  metadata?: MetadataItem[];
+}
+
+export default function MetadataCard({
+  posterUrl,
+  title,
+  rating,
+  voteCount,
+  genres,
+  releaseDate,
+  status,
+  metadata = [],
+}: MetadataCardProps) {
+  const formatValue = (value: string | number, format?: string) => {
+    if (format === 'currency') {
+      return `$${Number(value).toLocaleString()}`;
+    }
+    if (format === 'date') {
+      return new Date(value.toString()).toLocaleDateString();
+    }
+    if (format === 'number') {
+      return Number(value).toLocaleString();
+    }
+    return value;
+  };
+
+  return (
+    <div className="lg:col-span-1">
+      <div className="bg-white rounded-lg shadow-lg p-6">
+        {posterUrl && (
+          <Image
+            src={posterUrl}
+            alt={title}
+            width={342}
+            height={513}
+            className="w-full rounded-lg shadow-md mb-6"
+          />
+        )}
+
+        <div className="space-y-4">
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">Rating</h3>
+            <div className="flex items-center">
+              <span className="text-2xl font-bold text-yellow-500">
+                ⭐ {rating.toFixed(1)}
+              </span>
+              <span className="text-gray-500 ml-2">
+                ({voteCount.toLocaleString()} votes)
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">Genres</h3>
+            <div className="flex flex-wrap gap-2">
+              {genres.map((genre) => (
+                <span
+                  key={genre.id}
+                  className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm"
+                >
+                  {genre.name}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {releaseDate && (
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-2">Release Date</h3>
+              <p className="text-gray-700">
+                {new Date(releaseDate).toLocaleDateString()}
+              </p>
+            </div>
+          )}
+
+          {status && (
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-2">Status</h3>
+              <p className="text-gray-700">{status}</p>
+            </div>
+          )}
+
+          {metadata.map((item, index) => (
+            <div key={index}>
+              <h3 className="font-semibold text-gray-900 mb-2">{item.label}</h3>
+              <p className="text-gray-700">
+                {formatValue(item.value, item.format)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/OverviewSection/OverviewSection.tsx
+++ b/components/OverviewSection/OverviewSection.tsx
@@ -1,0 +1,14 @@
+interface OverviewSectionProps {
+  overview: string | null;
+}
+
+export default function OverviewSection({ overview }: OverviewSectionProps) {
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h2 className="text-2xl font-bold text-gray-900 mb-4">Overview</h2>
+      <p className="text-gray-700 leading-relaxed">
+        {overview || 'No overview available.'}
+      </p>
+    </div>
+  );
+}

--- a/components/ProductionCompanies/ProductionCompanies.tsx
+++ b/components/ProductionCompanies/ProductionCompanies.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image';
+import { tmdbImageUrl } from '@/lib/tmdb';
+import type { TMDBProductionCompany } from '@/types/tmdb';
+
+interface ProductionCompaniesProps {
+  companies: TMDBProductionCompany[];
+}
+
+export default function ProductionCompanies({
+  companies,
+}: ProductionCompaniesProps) {
+  if (!companies || companies.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h2 className="text-2xl font-bold text-gray-900 mb-6">
+        Production Companies
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {companies.map((company) => (
+          <div key={company.id} className="flex items-center space-x-3">
+            {company.logo_path ? (
+              <Image
+                src={tmdbImageUrl.poster(company.logo_path, 'w154') || ''}
+                alt={company.name}
+                width={50}
+                height={50}
+                className="w-12 h-12 object-contain"
+              />
+            ) : (
+              <div className="w-12 h-12 bg-gray-100 rounded flex items-center justify-center">
+                <span className="text-gray-400 text-xs">Logo</span>
+              </div>
+            )}
+            <div>
+              <h3 className="font-medium text-gray-900">{company.name}</h3>
+              {company.origin_country && (
+                <p className="text-gray-500 text-sm">
+                  {company.origin_country}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/SeasonsSection/SeasonsSection.tsx
+++ b/components/SeasonsSection/SeasonsSection.tsx
@@ -1,0 +1,66 @@
+import Image from 'next/image';
+import { tmdbImageUrl } from '@/lib/tmdb';
+
+interface Season {
+  air_date: string;
+  episode_count: number;
+  id: number;
+  name: string;
+  overview: string;
+  poster_path: string | null;
+  season_number: number;
+  vote_average: number;
+}
+
+interface SeasonsSectionProps {
+  seasons: Season[];
+}
+
+export default function SeasonsSection({ seasons }: SeasonsSectionProps) {
+  if (!seasons || seasons.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h2 className="text-2xl font-bold text-gray-900 mb-6">Seasons</h2>
+      <div className="space-y-4">
+        {seasons.map((season) => (
+          <div
+            key={season.id}
+            className="flex items-start space-x-4 p-4 border border-gray-200 rounded-lg"
+          >
+            {season.poster_path ? (
+              <Image
+                src={tmdbImageUrl.poster(season.poster_path, 'w154') || ''}
+                alt={season.name}
+                width={60}
+                height={90}
+                className="w-15 h-22 object-cover rounded"
+              />
+            ) : (
+              <div className="w-15 h-22 bg-gray-200 rounded flex items-center justify-center">
+                <span className="text-gray-400 text-xs">No Image</span>
+              </div>
+            )}
+            <div className="flex-1">
+              <h3 className="font-semibold text-gray-900 mb-1">
+                {season.name}
+              </h3>
+              <p className="text-gray-600 text-sm mb-2">
+                {season.episode_count} episodes
+                {season.air_date &&
+                  ` • Aired ${new Date(season.air_date).getFullYear()}`}
+              </p>
+              {season.overview && (
+                <p className="text-gray-500 text-sm line-clamp-2">
+                  {season.overview}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add dynamic routes for /movie/[id] and /tv/[id] with SSR
- Create 6 reusable components for better code organization: • HeroSection - backdrop image with title overlay • MetadataCard - poster, rating, genres, and metadata sidebar • OverviewSection - plot/overview display • CastGrid - actor photos and character names • CrewSection - key crew members with photos • ProductionCompanies - company logos and names • SeasonsSection - TV-specific seasons display
- Implement comprehensive metadata display (cast, crew, ratings, genres, etc.)
- Fix Next.js 15 compatibility with async params
- Add proper TypeScript interfaces and error handling